### PR TITLE
Small fix on cut when parsing keys.

### DIFF
--- a/nginx-cache-inspector
+++ b/nginx-cache-inspector
@@ -58,7 +58,7 @@ function get_cache_files() {
 ## Print the cache item key.
 ## $1 - cache file.
 function get_cache_item_key() {
-    cat $1 | sed -n '/^KEY:/p' | cut -f 2 -d ':'
+    cat $1 | sed -n '/^KEY:/p' | cut -f 2- -d ':'
 } # get_cache_item_key
 
 ## Get a cache item TTL.


### PR DESCRIPTION
If key contains ':' inside, key will be cut on first match of ':'. 

E.g: keys that contains full url (http://....) will always be shown as http.

Now cut will take everything after the first :, which would be the full key.
